### PR TITLE
feat: enhance model logging and add activity log retention

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,36 +50,114 @@ return [
         'on_login' => true,
     ],
 
+    // When true, updates will only log changed (dirty) attributes
+    'log_only_dirty' => true,
+
+    // The User model class used to resolve causer name/id
     'user_model' => '\App\Models\User',
 
+    // Which attribute on the causer to display in descriptions (e.g. name/email)
+    'causer_name_attribute' => 'name',
+
+    // Global fallback identifier used in descriptions when a model doesn't override it
+    'default_log_identifier' => 'id',
+
+    // API listing pagination size
     'log_pagination' => 20,
 
+    // Middleware used by the built-in logs API route
     'api_route_middleware' => 'auth:sanctum',
 
+    // Number of days to retain logs before pruning (default 365)
+    'retention_days' => 365,
 ];
 ```
 
 ## Usage
 
-Use trait `LogsActivity` on every model you want to log crud events.
+- Add the `LogsActivity` trait to any model you want to track.
+- Implement `ActivityLogContract` to strongly define your model's logging configuration.
+- By default, descriptions are standardized as: `"{causerName} {verb} {ModelName} '{identifier}'"`.
 
-```
-class User extends Authenticatable
+### Basic
+
+```php
+use Threls\ThrelsActivityLog\Traits\LogsActivity;
+
+class Product extends Model
 {
     use LogsActivity;
-
 }
 ```
 
-# Clear logs
+This will emit logs like: `Sabina created Product '42'` using the global `default_log_identifier`.
 
-```
- php artisan activity-log:delete
+### Per-model configuration via properties (no interface)
+
+```php
+class Product extends Model
+{
+    use LogsActivity;
+
+    public ?array $logAttributes = ['name', 'price'];
+    public ?array $ignoreAttributes = ['updated_at'];
+    public ?bool $logOnlyDirty = true; // only diffs on update
+    public ?string $logIdentifier = 'name'; // used in description
+}
 ```
 
-# Built in API to get logs list
+### Strict configuration via interface
 
+```php
+use Threls\ThrelsActivityLog\Contracts\ActivityLogContract;
+use Threls\ThrelsActivityLog\Enums\ActivityLogTypeEnum;
+
+class Product extends Model implements ActivityLogContract
+{
+    use LogsActivity;
+
+    public function getLogAttributes(): array|string|null { return ['name', 'price']; }
+    public function getIgnoreAttributes(): array|string|null { return ['updated_at']; }
+    public function getLogOnlyDirty(): ?bool { return true; }
+    public function getLogIdentifier(): ?string { return 'name'; }
+}
 ```
+
+### CLI / Queues safety
+- The package guards request-dependent values (user agent, IP). In non-HTTP contexts, defaults like `unknown` and `127.0.0.1` are used.
+
+### Maintenance
+
+#### Log Pruning (Recommended)
+This package supports Laravel's native model pruning. To keep your `activity_log` table small, you should schedule the `model:prune` command in your application's `routes/console.php` (or `app/Console/Kernel.php` for older Laravel versions):
+
+```php
+use Illuminate\Support\Facades\Schedule;
+use Threls\ThrelsActivityLog\Models\ActivityLog;
+
+Schedule::command('model:prune', [
+    '--model' => [ActivityLog::class],
+])->daily();
+```
+
+You can configure the retention period in `config/activity-log.php`:
+```php
+'retention_days' => 365, // Keep logs for 1 year
+```
+
+#### Manual Cleanup
+Alternatively, you can manually delete old logs using the provided command:
+
+```bash
+# Deletes logs older than 30 days
+php artisan activity-log:delete --older-than-days=30
+
+# Deletes logs using the 'retention_days' from config
+php artisan activity-log:delete
+```
+
+#### Built-in API to list logs
+```http
 GET /threls-activity-log/logs
 ```
 

--- a/config/activity-log.php
+++ b/config/activity-log.php
@@ -12,10 +12,14 @@ return [
         'on_login' => true,
     ],
 
+    'log_only_dirty' => true,
+
     'user_model' => '\App\Models\User',
 
     'log_pagination' => 20,
 
     'api_route_middleware' => 'auth:sanctum',
-
+    'default_log_identifier' => 'id',
+    'causer_name_attribute' => 'name',
+    'retention_days' => 365,
 ];

--- a/src/Commands/ThrelsDeleteActivityLogCommand.php
+++ b/src/Commands/ThrelsDeleteActivityLogCommand.php
@@ -7,20 +7,35 @@ use Threls\ThrelsActivityLog\Models\ActivityLog;
 
 class ThrelsDeleteActivityLogCommand extends Command
 {
-    public $signature = 'activity-log:delete {--older-than-months=}';
+    public $signature = 'activity-log:delete {--older-than-days=}';
 
     public $description = 'Delete activity log';
 
     public function handle(): int
     {
-        $olderThanMonths = $this->option('older-than-months');
-        ActivityLog::query()
-            ->when($olderThanMonths, function ($query) use ($olderThanMonths) {
-                $query->where('created_at', '<=', now()->subMonths((int) $olderThanMonths));
-            })
-            ->delete();
+        $olderThanDays = $this->option('older-than-days');
 
-        $this->comment('Cleared activity log table.');
+        if ($olderThanDays) {
+            $count = ActivityLog::query()
+                ->where('created_at', '<=', now()->subDays((int) $olderThanDays))
+                ->delete();
+
+            $this->info("Deleted {$count} activity log records older than {$olderThanDays} days.");
+
+            return self::SUCCESS;
+        }
+
+        $retentionDays = config('activity-log.retention_days');
+
+        if (! $retentionDays) {
+            $this->error('Please provide --older-than-days or configure retention_days.');
+
+            return self::FAILURE;
+        }
+
+        $count = (new ActivityLog)->prunable()->delete();
+
+        $this->info("Deleted {$count} activity log records using the retention period of {$retentionDays} days.");
 
         return self::SUCCESS;
     }

--- a/src/Contracts/ActivityLogContract.php
+++ b/src/Contracts/ActivityLogContract.php
@@ -2,13 +2,15 @@
 
 namespace Threls\ThrelsActivityLog\Contracts;
 
+use Threls\ThrelsActivityLog\Enums\ActivityLogTypeEnum;
+
 interface ActivityLogContract
 {
-    public function getActivityLogDisplayName(): string;
+    public function getLogAttributes(): array|string|null;
 
-    public function getCreateActivityDescription(): ?string;
+    public function getIgnoreAttributes(): array|string|null;
 
-    public function getUpdateActivityDescription(): ?string;
+    public function getLogIdentifier(): ?string;
 
-    public function getDeleteActivityDescription(): ?string;
+    public function getActivityLogDescription(ActivityLogTypeEnum $type): ?string;
 }

--- a/src/Data/ActivityLogData.php
+++ b/src/Data/ActivityLogData.php
@@ -17,6 +17,7 @@ class ActivityLogData
         public readonly array $dirty_keys,
         public readonly string $browser_name,
         public readonly string $platform,
+        public readonly string $device,
         public readonly string $ip,
         public Carbon $log_date
 
@@ -24,6 +25,11 @@ class ActivityLogData
 
     public static function fromArray(array $attributes): self
     {
+        $data = $attributes['data'];
+        if (is_array($data) && (isset($data['old']) || isset($data['new']))) {
+            $data = new ModelLogData($data['old'] ?? null, $data['new'] ?? null);
+        }
+
         return new self(
             $attributes['user_id'],
             $attributes['model_id'],
@@ -31,10 +37,11 @@ class ActivityLogData
             $attributes['table_name'],
             $attributes['type'],
             $attributes['description'] ?? null,
-            $attributes['data'],
+            $data,
             $attributes['dirty_keys'],
             $attributes['browser_name'],
             $attributes['platform'],
+            $attributes['device'] ?? 'unknown',
             $attributes['ip'],
             Carbon::parse($attributes['log_date']),
         );
@@ -49,10 +56,14 @@ class ActivityLogData
             'table_name' => $this->table_name,
             'type' => $this->type,
             'description' => $this->description,
-            'data' => $this->data,
+            'data' => [
+                'old' => $this->data->old,
+                'new' => $this->data->new,
+            ],
             'dirty_keys' => $this->dirty_keys,
             'browser_name' => $this->browser_name,
             'platform' => $this->platform,
+            'device' => $this->device,
             'ip' => $this->ip,
             'log_date' => $this->log_date->toDateTimeString(),
         ];

--- a/src/Data/ModelLogData.php
+++ b/src/Data/ModelLogData.php
@@ -5,7 +5,7 @@ namespace Threls\ThrelsActivityLog\Data;
 class ModelLogData
 {
     public function __construct(
-        public readonly ?array $oldContent,
-        public readonly ?array $newContent,
+        public readonly ?array $old,
+        public readonly ?array $new,
     ) {}
 }

--- a/src/Events/UserLoggedInEvent.php
+++ b/src/Events/UserLoggedInEvent.php
@@ -29,7 +29,7 @@ class UserLoggedInEvent
             'model_type' => get_class($model),
             'table_name' => $tableName,
             'type' => ActivityLogTypeEnum::LOGIN->value,
-            'data' => new ModelLogData(oldContent: null, newContent: null),
+            'data' => new ModelLogData(old: null, new: null),
             'dirty_keys' => [],
             'browser_name' => $agent->browser($userAgent),
             'platform' => $agent->platform($userAgent),

--- a/src/Models/ActivityLog.php
+++ b/src/Models/ActivityLog.php
@@ -2,12 +2,17 @@
 
 namespace Threls\ThrelsActivityLog\Models;
 
+use Illuminate\Database\Eloquent\MassPrunable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
+use Threls\ThrelsActivityLog\Contracts\ActivityLogContract;
+use Threls\ThrelsActivityLog\Enums\ActivityLogTypeEnum;
 
 class ActivityLog extends Model
 {
+    use MassPrunable;
+
     protected $table = 'activity_log';
 
     protected $guarded = ['id'];
@@ -17,24 +22,54 @@ class ActivityLog extends Model
         'dirty_keys' => 'array',
     ];
 
-    private mixed $userInstance = "\App\Models\User";
-
-    public function __construct()
-    {
-        parent::__construct();
-        $userInstance = config('activity-log.user_model');
-        if (! empty($userInstance)) {
-            $this->userInstance = $userInstance;
-        }
-    }
-
     public function user(): BelongsTo
     {
-        return $this->belongsTo($this->userInstance);
+        return $this->belongsTo(config('activity-log.user_model', 'App\Models\User'));
     }
 
     public function model(): MorphTo
     {
         return $this->morphTo();
+    }
+
+    public function scopeForModel($query, Model $model)
+    {
+        return $query->where([
+            'model_id' => $model->getKey(),
+            'model_type' => $model->getMorphClass(),
+        ]);
+    }
+
+    public function prunable()
+    {
+        $days = config('activity-log.retention_days');
+
+        if (! $days) {
+            return $this->whereRaw('1 = 0');
+        }
+
+        return $this->where('created_at', '<=', now()->subDays($days));
+    }
+
+    public function scopeOfType($query, string|ActivityLogTypeEnum $type)
+    {
+        return $query->where('type', $type instanceof ActivityLogTypeEnum ? $type->value : $type);
+    }
+
+    public function scopeForUser($query, $user)
+    {
+        return $query->where('user_id', $user instanceof Model ? $user->getKey() : $user);
+    }
+
+    public function getModelDisplayName(): string
+    {
+        if ($this->model instanceof ActivityLogContract) {
+            $identifierColumn = $this->model->getLogIdentifier();
+            if ($identifierColumn && isset($this->model->{$identifierColumn})) {
+                return (string) $this->model->{$identifierColumn};
+            }
+        }
+
+        return class_basename($this->model_type)." #{$this->model_id}";
     }
 }

--- a/src/Traits/LogsActivity.php
+++ b/src/Traits/LogsActivity.php
@@ -4,6 +4,9 @@ namespace Threls\ThrelsActivityLog\Traits;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
 use Jenssegers\Agent\Agent;
 use Threls\ThrelsActivityLog\Contracts\ActivityLogContract;
 use Threls\ThrelsActivityLog\Data\ActivityLogData;
@@ -18,48 +21,271 @@ trait LogsActivity
 {
     public static function createLogObject(Model $model, ?array $oldData, ActivityLogTypeEnum $logType): ?ActivityLogData
     {
+        $modelArray = self::getFilteredAttributes($model, $model->toArray());
+        $oldData = $oldData !== null ? self::getFilteredAttributes($model, $oldData) : null;
+
+        $dirtyKeys = [];
+        if ($logType === ActivityLogTypeEnum::UPDATE) {
+            $diff = self::computeDirtyDiff($modelArray, $oldData ?? [], $model);
+            if ($diff === null) {
+                return null;
+            }
+
+            $dirtyKeys = array_keys($diff['new'] ?? []);
+
+            if (self::resolveLogOnlyDirty($model)) {
+                $modelArray = $diff['new'];
+                $oldData = $diff['old'];
+            }
+        }
+
         $data = match ($logType) {
-            ActivityLogTypeEnum::CREATE, ActivityLogTypeEnum::UPDATE => new ModelLogData(oldContent: $oldData, newContent: $model->toArray()),
-            ActivityLogTypeEnum::DELETE => new ModelLogData(oldContent: $model->toArray(), newContent: null),
+            ActivityLogTypeEnum::CREATE, ActivityLogTypeEnum::UPDATE => new ModelLogData(old: $oldData, new: $modelArray),
+            ActivityLogTypeEnum::DELETE => new ModelLogData(old: $modelArray, new: null),
             default => null,
         };
 
-        $tableName = $model->getTable();
-        $userId = auth()->id();
+        $userId = self::resolveUserId();
+        $causerName = self::resolveCauserName($userId);
+
         $agent = new Agent;
-        $userAgent = request()->userAgent();
-
-        $description = null;
-        if ($model instanceof ActivityLogContract) {
-            $description = match ($logType) {
-                ActivityLogTypeEnum::CREATE => $model->getCreateActivityDescription(),
-                ActivityLogTypeEnum::UPDATE => $model->getUpdateActivityDescription(),
-                ActivityLogTypeEnum::DELETE => $model->getDeleteActivityDescription(),
-                default => null,
-            };
-        }
-
-        if ($description === null) {
-            $modelName = class_basename($model);
-            $verb = $logType->getVerb();
-            $description = "{$modelName} {$verb}";
-        }
+        $userAgent = request()?->userAgent();
 
         return ActivityLogData::fromArray([
             'user_id' => $userId,
             'model_id' => $model->id,
-            'model_type' => get_class($model),
-            'table_name' => $tableName,
+            'model_type' => $model::class,
+            'table_name' => $model->getTable(),
             'type' => $logType->value,
-            'description' => $description,
+            'description' => self::resolveDescription($model, $logType, $causerName),
             'data' => $data,
-            'dirty_keys' => array_keys($model->getChanges()),
-            'browser_name' => $agent->browser($userAgent),
-            'platform' => $agent->platform($userAgent),
-            'device' => $agent->device($userAgent),
-            'ip' => request()->ip(),
+            'dirty_keys' => $dirtyKeys,
+            'browser_name' => $userAgent ? $agent->browser($userAgent) : 'unknown',
+            'platform' => $userAgent ? $agent->platform($userAgent) : 'unknown',
+            'device' => $userAgent ? $agent->device($userAgent) : 'unknown',
+            'ip' => request()?->ip() ?? '127.0.0.1',
             'log_date' => now(),
         ]);
+    }
+
+    protected static function getFilteredAttributes(Model $model, array $attributes): array
+    {
+        $ignoreAttributes = self::resolveIgnoreAttributes($model);
+        $logAttributes = self::resolveLogAttributes($model);
+
+        if ($logAttributes !== null) {
+            $attributes = array_intersect_key($attributes, array_flip((array) $logAttributes));
+        }
+
+        $attributes = array_diff_key($attributes, array_flip((array) $ignoreAttributes));
+
+        return self::normalizeJsonColumns($attributes, $model);
+    }
+
+    protected static function resolveIgnoreAttributes(Model $model): array
+    {
+        if ($model instanceof ActivityLogContract && ($attrs = $model->getIgnoreAttributes()) !== null) {
+            return (array) $attrs;
+        }
+
+        return (property_exists($model, 'ignoreAttributes') && $model->ignoreAttributes !== null)
+            ? (array) $model->ignoreAttributes
+            : [];
+    }
+
+    protected static function resolveLogAttributes(Model $model): ?array
+    {
+        if ($model instanceof ActivityLogContract && ($attrs = $model->getLogAttributes()) !== null) {
+            return (array) $attrs;
+        }
+
+        return (property_exists($model, 'logAttributes') && $model->logAttributes !== null)
+            ? (array) $model->logAttributes
+            : null;
+    }
+
+    protected static function normalizeJsonColumns(?array $data, Model $model): ?array
+    {
+        if ($data === null) {
+            return null;
+        }
+
+        $casts = $model->getCasts();
+
+        foreach ($data as $key => $value) {
+            if (isset($casts[$key]) && ($casts[$key] === 'array' || $casts[$key] === 'json' || $casts[$key] === 'object' || str_contains($casts[$key], 'AsArrayObject') || str_contains($casts[$key], 'AsCollection'))) {
+                if (is_string($value)) {
+                    $decoded = json_decode($value, true);
+                    if (json_last_error() === JSON_ERROR_NONE) {
+                        $data[$key] = $decoded;
+                    }
+                }
+            } elseif (is_string($value) && str_starts_with($value, '{') && str_ends_with($value, '}')) {
+                $decoded = json_decode($value, true);
+                if (json_last_error() === JSON_ERROR_NONE) {
+                    $data[$key] = $decoded;
+                }
+            }
+        }
+
+        return $data;
+    }
+
+    protected static function resolveLogOnlyDirty(Model $model): bool
+    {
+        return property_exists($model, 'logOnlyDirty') && $model->logOnlyDirty !== null
+            ? $model->logOnlyDirty
+            : config('activity-log.log_only_dirty', false);
+    }
+
+    protected static function computeDirtyDiff(array $current, ?array $old, Model $model): ?array
+    {
+        $old = $old ?? [];
+        unset($current['updated_at'], $current['created_at'], $old['updated_at'], $old['created_at']);
+
+        $casts = $model->getCasts();
+        $changes = [];
+
+        foreach ($current as $key => $value) {
+            if (! array_key_exists($key, $old) || self::isAttributeDifferent($value, $old[$key], $key, $casts)) {
+                $changes[$key] = self::formatAttributeValue($value, $key, $casts);
+            }
+        }
+
+        if (empty($changes)) {
+            return null;
+        }
+
+        $oldData = [];
+        foreach (array_intersect_key($old, $changes) as $key => $value) {
+            $oldData[$key] = self::formatAttributeValue($value, $key, $casts);
+        }
+
+        return ['new' => $changes, 'old' => $oldData];
+    }
+
+    protected static function isAttributeDifferent(mixed $a, mixed $b, string $key, array $casts): bool
+    {
+        if (is_array($a) && is_array($b)) {
+            if (count($a) !== count($b)) {
+                return true;
+            }
+
+            ksort($a);
+            ksort($b);
+
+            foreach ($a as $k => $value) {
+                if (! array_key_exists($k, $b) || self::isAttributeDifferent($value, $b[$k], $k, $casts)) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        if (isset($casts[$key])) {
+            $cast = $casts[$key];
+            if ($cast === 'date' || $cast === 'datetime' || str_starts_with($cast, 'date:') || str_starts_with($cast, 'datetime:')) {
+                return self::isDateDifferent($a, $b, $cast);
+            }
+        }
+
+        return (is_array($a) || is_array($b)) || (string) $a !== (string) $b;
+    }
+
+    protected static function isDateDifferent(mixed $a, mixed $b, string $cast): bool
+    {
+        try {
+            if ($a === null && $b === null) {
+                return false;
+            }
+
+            if ($a === null || $b === null) {
+                return true;
+            }
+
+            $tz = config('app.timezone');
+            $dateA = Carbon::parse($a)->setTimezone($tz);
+            $dateB = Carbon::parse($b)->setTimezone($tz);
+
+            if ($cast === 'date' || str_starts_with($cast, 'date:')) {
+                return $dateA->toDateString() !== $dateB->toDateString();
+            }
+
+            return ! $dateA->equalTo($dateB);
+        } catch (\Exception) {
+            return (string) $a !== (string) $b;
+        }
+    }
+
+    protected static function formatAttributeValue(mixed $value, string $key, array $casts): mixed
+    {
+        if ($value === null || ! isset($casts[$key])) {
+            return $value;
+        }
+
+        $cast = $casts[$key];
+        if ($cast === 'date' || str_starts_with($cast, 'date:')) {
+            return Carbon::parse($value)->toDateString();
+        }
+
+        if ($cast === 'datetime' || str_starts_with($cast, 'datetime:')) {
+            $format = str_contains($cast, ':') ? explode(':', $cast)[1] : 'Y-m-d H:i:s';
+
+            return Carbon::parse($value)->format($format);
+        }
+
+        return $value;
+    }
+
+    protected static function resolveUserId(): ?string
+    {
+        return auth()->id() ?? null;
+    }
+
+    protected static function resolveCauserName(?string $userId): string
+    {
+        if (! $userId) {
+            return 'Unknown';
+        }
+
+        $nameAttr = config('activity-log.causer_name_attribute', 'name');
+
+        if (($authUser = auth()->user()) && isset($authUser->{$nameAttr})) {
+            return (string) $authUser->{$nameAttr};
+        }
+
+        $userModelClass = config('activity-log.user_model', 'App\\Models\\User');
+        if (class_exists($userModelClass) && ($user = $userModelClass::find($userId)) && isset($user->{$nameAttr})) {
+            return (string) $user->{$nameAttr};
+        }
+
+        if (Schema::hasTable('users') && ($record = DB::table('users')->find($userId)) && isset($record->{$nameAttr})) {
+            return (string) $record->{$nameAttr};
+        }
+
+        return 'Unknown';
+    }
+
+    protected static function resolveDescription(Model $model, ActivityLogTypeEnum $logType, string $causerName): string
+    {
+        $customDescription = $model instanceof ActivityLogContract
+            ? $model->getActivityLogDescription($logType)
+            : (method_exists($model, 'getActivityLogDescription') ? $model->getActivityLogDescription($logType) : null);
+
+        if (is_string($customDescription) && $customDescription !== '') {
+            return $customDescription;
+        }
+
+        $identifierColumn = $model instanceof ActivityLogContract
+            ? $model->getLogIdentifier()
+            : (property_exists($model, 'logIdentifier') ? $model->logIdentifier : null);
+
+        $identifierColumn ??= config('activity-log.default_log_identifier', 'id');
+
+        $identifier = $model->getAttribute($identifierColumn) ?? $model->getKey();
+
+        return "{$causerName} {$logType->getVerb()} ".class_basename($model)." '{$identifier}'";
     }
 
     protected static function checkLoggingIsEnabled()
@@ -74,26 +300,40 @@ trait LogsActivity
         }
 
         if (config('activity-log.log_events.on_update', false)) {
-            self::saved(function ($model) {
-                if (! $model->wasRecentlyCreated) {
-                    $object = self::createLogObject($model, $model->getRawOriginal(), ActivityLogTypeEnum::UPDATE);
-                    event(new ModelUpdatedEvent($object, $model));
+            static $oldData = [];
+
+            self::updating(function ($model) use (&$oldData) {
+                $oldData[$model->getKey()] = $model->getRawOriginal();
+
+                if (self::resolveLogOnlyDirty($model)) {
+                    self::logModelEvent($model, $oldData[$model->getKey()], ActivityLogTypeEnum::UPDATE, ModelUpdatedEvent::class);
                 }
+            });
+
+            self::saved(function ($model) use (&$oldData) {
+                if (! self::resolveLogOnlyDirty($model) && ! $model->wasRecentlyCreated) {
+                    self::logModelEvent($model, $oldData[$model->getKey()] ?? null, ActivityLogTypeEnum::UPDATE, ModelUpdatedEvent::class);
+                }
+
+                unset($oldData[$model->getKey()]);
             });
         }
 
         if (config('activity-log.log_events.on_delete', false)) {
-            self::deleted(function ($model) {
-                $object = self::createLogObject($model, null, ActivityLogTypeEnum::DELETE);
-                event(new ModelDeletedEvent($object, $model));
-            });
+            self::deleted(fn ($model) => self::logModelEvent($model, null, ActivityLogTypeEnum::DELETE, ModelDeletedEvent::class));
         }
 
         if (config('activity-log.log_events.on_create', false)) {
-            self::created(function ($model) {
-                $object = self::createLogObject($model, null, ActivityLogTypeEnum::CREATE);
-                event(new ModelCreatedEvent($object, $model));
-            });
+            self::created(fn ($model) => self::logModelEvent($model, null, ActivityLogTypeEnum::CREATE, ModelCreatedEvent::class));
+        }
+    }
+
+    protected static function logModelEvent(Model $model, ?array $oldData, ActivityLogTypeEnum $type, string $eventClass): void
+    {
+        $logObject = self::createLogObject($model, $oldData, $type);
+
+        if ($logObject !== null) {
+            event(new $eventClass($logObject, $model));
         }
     }
 

--- a/tests/Feature/DateLoggingTest.php
+++ b/tests/Feature/DateLoggingTest.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace Threls\ThrelsActivityLog\Tests\Feature;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Threls\ThrelsActivityLog\Contracts\ActivityLogContract;
+use Threls\ThrelsActivityLog\Enums\ActivityLogTypeEnum;
+use Threls\ThrelsActivityLog\Models\ActivityLog;
+use Threls\ThrelsActivityLog\Tests\TestCase;
+use Threls\ThrelsActivityLog\Traits\LogsActivity;
+
+class DateLoggingTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Schema::create('date_test_models', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->date('onboarding_date')->nullable();
+            $table->dateTime('onboarding_datetime')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function test_it_does_not_log_unchanged_date_columns()
+    {
+        $model = new DateTestModel;
+        $model->name = 'Test';
+        $model->onboarding_date = '2026-02-28';
+        $model->save();
+
+        ActivityLog::query()->delete();
+
+        $model->onboarding_date = '2026-02-28';
+        $model->save();
+
+        $this->assertEquals(0, ActivityLog::count(), 'Activity log was created even though date was not changed');
+
+        // Force an update with the same date but in a different format/type if possible
+        $model->onboarding_date = \Carbon\Carbon::parse('2026-02-28')->startOfDay();
+        $model->save();
+
+        $this->assertEquals(0, ActivityLog::count(), 'Activity log was created even though date was same but different type');
+    }
+
+    public function test_it_does_not_log_unchanged_datetime_columns()
+    {
+        $model = new DateTestModel;
+        $model->name = 'Test';
+        $model->onboarding_datetime = '2026-02-27 23:00:00';
+        $model->save();
+
+        ActivityLog::query()->delete();
+
+        $model->onboarding_datetime = '2026-02-27 23:00:00';
+        $model->save();
+
+        $this->assertEquals(0, ActivityLog::count(), 'Activity log was created even though datetime was not changed');
+
+        // Force update with Carbon object
+        $model->onboarding_datetime = \Carbon\Carbon::parse('2026-02-27 23:00:00');
+        $model->save();
+
+        $this->assertEquals(0, ActivityLog::count(), 'Activity log was created even though datetime was same but Carbon object');
+    }
+
+    public function test_it_logs_date_correctly_on_update()
+    {
+        $model = new DateTestModel;
+        $model->name = 'Date Test';
+        $model->onboarding_date = '2026-02-28';
+        $model->save();
+
+        ActivityLog::truncate();
+
+        $model->update([
+            'onboarding_date' => '2026-02-26',
+        ]);
+
+        $log = ActivityLog::first();
+        expect($log)->not->toBeNull();
+
+        $data = $log->data;
+        // The issue states that new onboarding_date is saved as datetime string instead of date string
+        // {"new": {"onboarding_date": "2026-02-26T23:00:00.000000Z"}, "old": {"onboarding_date": "2026-02-28"}}
+
+        expect($data['new']['onboarding_date'])->toBe('2026-02-26');
+        expect($data['old']['onboarding_date'])->toBe('2026-02-28');
+    }
+
+    public function test_it_logs_datetime_correctly_on_update()
+    {
+        $model = new DateTestModel;
+        $model->name = 'DateTime Test';
+        $model->onboarding_datetime = '2026-02-27 23:00:00';
+        $model->save();
+
+        ActivityLog::truncate();
+
+        $model->update([
+            'onboarding_datetime' => '2026-02-28 10:00:00',
+        ]);
+
+        $log = ActivityLog::first();
+        expect($log)->not->toBeNull();
+
+        $data = $log->data;
+        expect($data['new']['onboarding_datetime'])->toBe('2026-02-28 10:00:00');
+        expect($data['old']['onboarding_datetime'])->toBe('2026-02-27 23:00:00');
+    }
+}
+
+class DateTestModel extends Model implements ActivityLogContract
+{
+    use LogsActivity;
+
+    protected $fillable = ['name', 'onboarding_date', 'onboarding_datetime'];
+
+    public $logOnlyDirty = true;
+
+    protected function casts(): array
+    {
+        return [
+            'onboarding_date' => 'date',
+            'onboarding_datetime' => 'datetime',
+        ];
+    }
+
+    public function getLogAttributes(): array|string|null
+    {
+        return ['name', 'onboarding_date', 'onboarding_datetime'];
+    }
+
+    public function getIgnoreAttributes(): array|string|null
+    {
+        return null;
+    }
+
+    public function getLogIdentifier(): ?string
+    {
+        return 'name';
+    }
+
+    public function getActivityLogDescription(ActivityLogTypeEnum $logType): ?string
+    {
+        return null;
+    }
+}

--- a/tests/Feature/LoggingTest.php
+++ b/tests/Feature/LoggingTest.php
@@ -1,0 +1,216 @@
+<?php
+
+namespace Threls\ThrelsActivityLog\Tests\Feature;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Threls\ThrelsActivityLog\Contracts\ActivityLogContract;
+use Threls\ThrelsActivityLog\Enums\ActivityLogTypeEnum;
+use Threls\ThrelsActivityLog\Models\ActivityLog;
+use Threls\ThrelsActivityLog\Tests\TestCase;
+use Threls\ThrelsActivityLog\Traits\LogsActivity;
+
+class TestModel extends Model implements ActivityLogContract
+{
+    use LogsActivity;
+
+    protected $table = 'test_models';
+
+    protected $guarded = [];
+
+    public ?array $ignoreAttributes = null;
+
+    public ?array $logAttributes = null;
+
+    public ?bool $logOnlyDirty = null;
+
+    public ?string $logIdentifier = null;
+
+    public ?string $customDescriptionText = null;
+
+    public function getLogAttributes(): array|string|null
+    {
+        return $this->logAttributes;
+    }
+
+    public function getIgnoreAttributes(): array|string|null
+    {
+        return $this->ignoreAttributes;
+    }
+
+    public function getLogIdentifier(): ?string
+    {
+        return $this->logIdentifier;
+    }
+
+    protected function casts(): array
+    {
+        return [
+            'settings' => 'array',
+        ];
+    }
+
+    public function getActivityLogDescription(ActivityLogTypeEnum $logType): ?string
+    {
+        return $this->customDescriptionText;
+    }
+}
+
+class LoggingTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Schema::create('test_models', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('email')->nullable();
+            $table->string('password')->nullable();
+            $table->json('settings')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function test_it_does_not_log_unchanged_json_columns()
+    {
+        $model = TestModel::create([
+            'name' => 'JSON Test',
+            'settings' => ['theme' => 'dark', 'notifications' => true, 'tags' => ['a', 'b']],
+        ]);
+
+        ActivityLog::truncate();
+        $model->logOnlyDirty = true;
+
+        // Update with same data but different key order in root
+        $model->update([
+            'settings' => ['notifications' => true, 'theme' => 'dark', 'tags' => ['a', 'b']],
+        ]);
+
+        expect(ActivityLog::count())->toBe(0);
+
+        // Update with same data as a JSON string (if someone passes it like that)
+        $model->update([
+            'settings' => json_encode(['notifications' => true, 'theme' => 'dark', 'tags' => ['a', 'b']]),
+        ]);
+        expect(ActivityLog::count())->toBe(0);
+
+        // Update with different data in nested array
+        $model->update([
+            'settings' => ['notifications' => true, 'theme' => 'dark', 'tags' => ['b', 'a']],
+        ]);
+        expect(ActivityLog::count())->toBe(1);
+    }
+
+    public function test_it_respects_ignored_attributes_on_model()
+    {
+        $model = new TestModel;
+        $model->ignoreAttributes = ['password'];
+        $model->fill([
+            'name' => 'John',
+            'email' => 'john@example.com',
+            'password' => 'secret',
+        ])->save();
+
+        $log = ActivityLog::first();
+        expect($log->data['new'])->not->toHaveKey('password')
+            ->and($log->data['new'])->toHaveKey('name');
+    }
+
+    public function test_it_respects_log_attributes_on_model()
+    {
+        $model = new TestModel;
+        $model->logAttributes = ['name'];
+        $model->fill(['name' => 'John', 'email' => 'john@example.com'])->save();
+
+        $log = ActivityLog::first();
+        expect($log->data['new'])->toHaveKey('name')
+            ->and($log->data['new'])->not->toHaveKey('email');
+    }
+
+    public function test_it_respects_log_only_dirty_on_model()
+    {
+        $model = TestModel::create(['name' => 'John', 'email' => 'john@example.com']);
+        ActivityLog::truncate();
+
+        $model->logOnlyDirty = true;
+
+        // Update non-tracked field
+        $model->update(['name' => 'John Doe']);
+
+        $log = ActivityLog::first();
+        expect($log->type)->toBe(ActivityLogTypeEnum::UPDATE->value)
+            ->and($log->data['new'])->toBe(['name' => 'John Doe'])
+            ->and($log->data['old'])->toBe(['name' => 'John']);
+
+        ActivityLog::truncate();
+
+        // Update with same data
+        $model->update(['name' => 'John Doe']);
+        expect(ActivityLog::count())->toBe(0);
+    }
+
+    public function test_it_works_in_cli_context()
+    {
+        $model = TestModel::create(['name' => 'CLI User']);
+
+        $log = ActivityLog::first();
+        expect($log->browser_name)->toBeString()
+            ->and($log->ip)->toBeString();
+    }
+
+    public function test_it_provides_helpful_scopes()
+    {
+        $model1 = TestModel::create(['name' => 'Model 1']);
+        $model2 = TestModel::create(['name' => 'Model 2']);
+
+        expect(ActivityLog::forModel($model1)->count())->toBe(1)
+            ->and(ActivityLog::forModel($model2)->count())->toBe(1)
+            ->and(ActivityLog::ofType(ActivityLogTypeEnum::CREATE)->count())->toBe(2);
+    }
+
+    public function test_it_builds_description_with_default_identifier()
+    {
+        $user = \Illuminate\Support\Facades\DB::table('users')->insertGetId([
+            'name' => 'Sabina',
+            'email' => 'sabina@example.com',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+        auth()->loginUsingId($user);
+
+        $model = TestModel::create(['name' => 'Test Item']);
+        $log = ActivityLog::first();
+        expect($log->description)->toBe("Sabina created TestModel '{$model->id}'");
+    }
+
+    public function test_it_respects_log_identifier_on_model()
+    {
+        $user = \Illuminate\Support\Facades\DB::table('users')->insertGetId([
+            'name' => 'Sabina',
+            'email' => 'sabina@example.com',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+        auth()->loginUsingId($user);
+
+        $model = new TestModel;
+        $model->logIdentifier = 'name';
+        $model->fill(['name' => 'Custom Name'])->save();
+
+        $log = ActivityLog::first();
+        expect($log->description)->toBe("Sabina created TestModel 'Custom Name'");
+    }
+
+    public function test_it_respects_custom_description_method()
+    {
+        $model = new TestModel;
+        $model->fill(['name' => 'Special Item']);
+        $model->customDescriptionText = 'Custom description for Special Item';
+        $model->save();
+
+        $log = ActivityLog::first();
+        expect($log->description)->toBe('Custom description for Special Item');
+    }
+}

--- a/tests/Feature/PruningTest.php
+++ b/tests/Feature/PruningTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Threls\ThrelsActivityLog\Tests\Feature;
+
+use Illuminate\Support\Facades\Artisan;
+use Threls\ThrelsActivityLog\Models\ActivityLog;
+use Threls\ThrelsActivityLog\Tests\TestCase;
+
+class PruningTest extends TestCase
+{
+    public function test_it_prunes_old_logs()
+    {
+        // Create an old log
+        $oldLog = ActivityLog::create([
+            'type' => 'create',
+            'data' => [],
+            'browser_name' => 'Chrome',
+            'platform' => 'Mac',
+            'device' => 'Desktop',
+            'ip' => '127.0.0.1',
+        ]);
+        $oldLog->created_at = now()->subDays(400);
+        $oldLog->save();
+
+        // Create a new log
+        ActivityLog::create([
+            'type' => 'create',
+            'data' => [],
+            'browser_name' => 'Chrome',
+            'platform' => 'Mac',
+            'device' => 'Desktop',
+            'ip' => '127.0.0.1',
+        ]);
+
+        config(['activity-log.retention_days' => 365]);
+
+        expect(ActivityLog::count())->toBe(2);
+
+        Artisan::call('model:prune', [
+            '--model' => [ActivityLog::class],
+        ]);
+
+        expect(ActivityLog::count())->toBe(1)
+            ->and(ActivityLog::find($oldLog->id))->toBeNull();
+    }
+
+    public function test_it_deletes_via_command()
+    {
+        // Create an old log
+        $oldLog = ActivityLog::create([
+            'type' => 'create',
+            'data' => [],
+            'browser_name' => 'Chrome',
+            'platform' => 'Mac',
+            'device' => 'Desktop',
+            'ip' => '127.0.0.1',
+        ]);
+        $oldLog->created_at = now()->subDays(100);
+        $oldLog->save();
+
+        ActivityLog::create([
+            'type' => 'create',
+            'data' => [],
+            'browser_name' => 'Chrome',
+            'platform' => 'Mac',
+            'device' => 'Desktop',
+            'ip' => '127.0.0.1',
+        ]);
+
+        // Test with option
+        Artisan::call('activity-log:delete', ['--older-than-days' => 50]);
+        expect(ActivityLog::count())->toBe(1);
+
+        // Reset and test with config
+        $oldLog = ActivityLog::create([
+            'type' => 'create',
+            'data' => [],
+            'browser_name' => 'Chrome',
+            'platform' => 'Mac',
+            'device' => 'Desktop',
+            'ip' => '127.0.0.1',
+        ]);
+        $oldLog->created_at = now()->subDays(100);
+        $oldLog->save();
+
+        config(['activity-log.retention_days' => 50]);
+        Artisan::call('activity-log:delete');
+        expect(ActivityLog::count())->toBe(1);
+    }
+}

--- a/tests/Feature/SoftDeleteLoggingTest.php
+++ b/tests/Feature/SoftDeleteLoggingTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Threls\ThrelsActivityLog\Tests\Feature;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Threls\ThrelsActivityLog\Models\ActivityLog;
+use Threls\ThrelsActivityLog\Tests\TestCase;
+use Threls\ThrelsActivityLog\Traits\LogsActivity;
+
+class SoftDeleteLoggingTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Schema::create('soft_delete_models', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->softDeletes();
+            $table->timestamps();
+        });
+
+        config(['activity-log.log_events.on_update' => true]);
+    }
+
+    public function test_it_does_not_log_deleted_at_when_it_remains_null()
+    {
+        config(['activity-log.log_events.on_create' => true]);
+        $model = SoftDeleteModel::create(['name' => 'Initial Name']);
+
+        $model->update(['name' => 'Updated Name']);
+
+        $log = ActivityLog::where('type', 'update')->latest()->first();
+
+        $this->assertNotNull($log);
+        $this->assertEquals('update', $log->type);
+        $this->assertArrayHasKey('new', $log->data);
+
+        // This should pass if everything is working correctly
+        $this->assertArrayNotHasKey('deleted_at', $log->data['new'], 'deleted_at was logged as dirty but should have been null in both old and new data');
+    }
+
+    public function test_it_logs_deleted_at_when_it_is_changed()
+    {
+        config(['activity-log.log_events.on_create' => true]);
+        config(['activity-log.log_events.on_delete' => true]);
+        $model = SoftDeleteModel::create(['name' => 'Initial Name']);
+
+        $model->delete();
+
+        $log = ActivityLog::where('type', 'delete')->latest()->first();
+
+        $this->assertNotNull($log);
+        $this->assertEquals('delete', $log->type);
+        // On delete, we log the old data.
+        $this->assertArrayHasKey('deleted_at', $log->data['old']);
+    }
+}
+
+class SoftDeleteModel extends Model
+{
+    use LogsActivity, SoftDeletes;
+
+    protected $fillable = ['name'];
+
+    protected $table = 'soft_delete_models';
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,6 +3,8 @@
 namespace Threls\ThrelsActivityLog\Tests;
 
 use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
 use Orchestra\Testbench\TestCase as Orchestra;
 use Threls\ThrelsActivityLog\ThrelsActivityLogServiceProvider;
 
@@ -27,11 +29,23 @@ class TestCase extends Orchestra
     public function getEnvironmentSetUp($app)
     {
         config()->set('database.default', 'testing');
+        config()->set('queue.default', 'sync');
 
-        /*
-         foreach (\Illuminate\Support\Facades\File::allFiles(__DIR__ . '/database/migrations') as $migration) {
-            (include $migration->getRealPath())->up();
-         }
-         */
+        Schema::create('users', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('email');
+            $table->timestamps();
+        });
+
+        $migrations = [
+            include __DIR__.'/../database/migrations/2025_02_11_164955_create_activity_log_table.php',
+            include __DIR__.'/../database/migrations/2025_03_13_142844_update_activity_log.php',
+            include __DIR__.'/../database/migrations/2025_03_17_000001_add_description_to_activity_log.php',
+        ];
+
+        foreach ($migrations as $migration) {
+            $migration->up();
+        }
     }
 }


### PR DESCRIPTION
- 'ActivityLog` model with configurable  `retention_days`.
- Update `ThrelsDeleteActivityLogCommand` to use the pruning logic.
- Add `getModelDisplayName()` to `ActivityLog` for better model identification.
- Improve `LogsActivity` trait and `ActivityLogContract` for more robust logging.
- Added description generation based on log identifier column , part of `ActivityLogContract'.
- Add `causer_name_attribute` and `retention_days` to the configuration.
- Add comprehensive tests for pruning, soft deletes, and date-based logging.
- Update documentation in README for new configuration options.